### PR TITLE
Incorrect variable reference in constructor had broken the _logIn() function

### DIFF
--- a/GoogleVoice.php
+++ b/GoogleVoice.php
@@ -20,7 +20,7 @@ class GoogleVoice {
 	public function __construct($login, $pass) {
 		$this->_login = $login;
 		$this->_pass = $pass;
-		$this->_cookie_file = '/tmp/gvCookies.txt';
+		$this->_cookieFile = '/tmp/gvCookies.txt';
 
 		$this->_ch = curl_init();
 		curl_setopt($this->_ch, CURLOPT_COOKIEJAR, $this->_cookieFile);


### PR DESCRIPTION
The _logIn() function wasn't working because the constructor was setting the value of _cookie_file (a nonexistent property) instead of _cookieFile, the property that the cURL cookiejar option is set to in the constructor.
