### PR TITLE
Fix finding GALX token

### DIFF
--- a/GoogleVoice.php
+++ b/GoogleVoice.php
@@ -40,7 +40,7 @@ class GoogleVoice {
 		$html = curl_exec($this->_ch);
 
 		// Parse the returned webpage for the "GALX" token, needed for POST requests.
-		if(preg_match('/name="GALX"\s*value="([^"]+)"/', $html, $match))
+		if (preg_match('/name="GALX"\s*type="hidden"\s*value="([^"]+)"/', $html, $match))
 			$GALX = $match[1];
 		else
 			throw new Exception('Could not parse for GALX token');


### PR DESCRIPTION
Google seems to have added an additional property between the name and value for the GALX field, which breaks the current regex.  This fixes that issue.
